### PR TITLE
Update conversion2.html

### DIFF
--- a/conversion2.html
+++ b/conversion2.html
@@ -20,11 +20,19 @@
   const day31str = new Date(day31).toISOString().slice(0, 10);
   
   gtag('event', 'purchase', {
-      'send_to': [
-        'AW-376259107/HxrjCJuu1uICEKOEtbMB', 
-        'G-G55HQ8G49M'
-      ],
+      'send_to': 'AW-376259107/HxrjCJuu1uICEKOEtbMB',
       'transaction_id': Date.now(),
+      'value': 50,
+      'currency': 'USD',
+      'items': [{
+        'id': '220',
+        'start_date': day30str,
+        'end_date': day31str
+      }]
+  });
+  gtag('event', 'purchase', {
+      'send_to': 'G-G55HQ8G49M',
+      'transaction_id': Date.now()+1,
       'value': 50,
       'currency': 'USD',
       'items': [{


### PR DESCRIPTION
update the transaction id to be different for Google Analytics conversions and Google Ads conversions

Currently, the GA conversions are not being imported into Google Ads because they have the same transaction id and being de-duped.